### PR TITLE
Update SqueakExpPanel.m

### DIFF
--- a/+eui/SqueakExpPanel.m
+++ b/+eui/SqueakExpPanel.m
@@ -82,6 +82,12 @@ classdef SqueakExpPanel < eui.ExpPanel
       %       fprintf('processing %i signal updates\n', length(updates));
       for ui = 1:length(updates)
         signame = updates(ui).name;
+
+        % ETHAN ADDED 2026 02 08: Hide analysis-only signals from GUI
+        if strncmp(signame, 'events.hide_', numel('events.hide_'))
+          continue
+        end
+        
         switch signame
           case {'inputs.wheel', 'pars'}
           otherwise


### PR DESCRIPTION
if events have the prefix 'hide_' (e.g. evts.hide_newTrial), they are not shown on the MC GUI.