### PR TITLE
Enable AO background mode

### DIFF
--- a/+hw/DaqController.m
+++ b/+hw/DaqController.m
@@ -162,11 +162,11 @@ classdef DaqController < handle
           queue(obj, channelNames(analogueChannelsIdx), waveforms(analogueChannelsIdx));
           if foreground
             startForeground(obj.DaqSession);
+            readyWait(obj);
+            obj.DaqSession.release;
           else
             startBackground(obj.DaqSession);
           end
-          readyWait(obj);
-          obj.DaqSession.release;
         elseif any(~analogueChannelsIdx)
             waveforms = waveforms(~analogueChannelsIdx);
             for n = 1:length(waveforms)

--- a/+hw/LEDpulseSwitcher.m
+++ b/+hw/LEDpulseSwitcher.m
@@ -11,6 +11,7 @@ classdef LedPulsePasser < hw.ControlSignalGenerator
 
   properties
     ClosedValue (1,1) double = 0
+    EndPaddingSeconds (1,1) double = 3
 
     % Safety limits
     MinVoltage  (1,1) double = 0
@@ -75,8 +76,8 @@ classdef LedPulsePasser < hw.ControlSignalGenerator
       samples = (openV - obj.ClosedValue) .* gate01 + obj.ClosedValue;
 
       % ensure return to baseline
-      samples = [samples; obj.ClosedValue];
-    end
+      padSamples = round(obj.EndPaddingSeconds * sampleRate);
+      samples = [samples; repmat(obj.ClosedValue, padSamples, 1)];    end
   end
 
   methods (Access = private)

--- a/+hw/LEDpulseSwitcher.m
+++ b/+hw/LEDpulseSwitcher.m
@@ -1,4 +1,4 @@
-classdef LedPulsePasser < hw.ControlSignalGenerator
+classdef LEDpulseSwitcher < hw.ControlSignalGenerator
   % HW.LEDPULSEPASSSER Pulse Generator based on pulseSwitcher, but takes a
   % power input which determines analog voltage input to LED driver
   %


### PR DESCRIPTION
AOs default to background when no mode is specified. This change stops background mode from telling the daq to stop sampling wheel data during AOs. I also added an adjustable pad time to the LEDpulseSwitcher (renamed due to change in intended purpose) so that the ~50msec dropout time at AO waveform offset can be manually moved outside the period of interest for wheel data.